### PR TITLE
ensure /run/initramfs exists 

### DIFF
--- a/initrd/init
+++ b/initrd/init
@@ -645,7 +645,8 @@ main_core() {
     write_output_files $OUTPUT_DIR
     update_store_file "$NO_STORE" "$DO_STORE"
 
-    mkdir -p $NEW_ROOT/etc/live
+    #ensure certain direcotries exist, including FINAL_DIR
+    mkdir -p $NEW_ROOT/etc/live $NEW_ROOT$FINAL_DIR
 
     echo $FINAL_DIR > $NEW_ROOT/etc/live/live-dir
 

--- a/initrd/live/custom/MX/8.sh
+++ b/initrd/live/custom/MX/8.sh
@@ -13,6 +13,9 @@ antix_specific_code() {
 
     rm -f $dir/etc/fstab.hotplug
     
+    #remove leftover /live directory (after switch_root)
+    rm -R $dir/live
+    #symlink /live to FINAL_DIR location after switch_root
     ln -s /run/initramfs $dir/live
     
     local protect=$dir/etc/live/protect


### PR DESCRIPTION
doesn't exist if not made from a remastered system that includes it already.